### PR TITLE
Interface changes for forensicmatt/r-winreg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ num-traits = "0.2"
 num-derive = "0.3"
 thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
+trace-error = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/omerbenamram/winstrcuts"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
-version = "0.3.1-alpha.0"
+version = "0.3.1-alpha.0-janstarke.1"
 authors = ["Omer Ben-Amram <omerbenamram@gmail.com>", "Matthew Seyer <matthew.seyer@gmail.com>"]
 edition = "2018"
 

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -10,5 +10,5 @@ mod sid;
 pub use self::ace::{Ace, AceBasic, AceData, AceObject, AceType};
 pub use self::acl::Acl;
 pub use self::authority::{Authority, SubAuthority, SubAuthorityList};
-pub use self::sec_desc::{SecDescHeader, SecurityDescriptor};
+pub use self::sec_desc::{SecDescHeader, SecurityDescriptor, SecDescError};
 pub use self::sid::Sid;

--- a/src/security/sec_desc.rs
+++ b/src/security/sec_desc.rs
@@ -4,6 +4,7 @@ use crate::security::sid::Sid;
 use crate::ReadSeek;
 use bitflags::bitflags;
 use byteorder::{LittleEndian, ReadBytesExt};
+use trace_error::backtrace;
 
 use serde::Serialize;
 
@@ -132,6 +133,29 @@ impl SecDescHeader {
             sacl_offset,
             dacl_offset,
         })
+    }
+}
+
+
+#[derive(Debug,Clone)]
+pub enum SdErrorKind {
+    IoError,
+    ValidationError
+}
+
+#[derive(Debug,Clone)]
+pub struct SecDescError {
+    pub message: String,
+    pub kind: SdErrorKind,
+    pub trace: String   
+}
+impl From<std::io::Error> for SecDescError {
+    fn from(err: std::io::Error) -> Self {
+        SecDescError {
+            message: format!("{}",err),
+            kind: SdErrorKind::IoError,
+            trace: backtrace!()
+        }
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -29,6 +29,10 @@ impl WinTimestamp {
         Self::from_reader(&mut Cursor::new(buffer))
     }
 
+    pub fn from(value: u64) -> Self {
+        Self(value)
+    }
+
     #[inline]
     pub fn from_reader<R: Read>(reader: &mut R) -> Result<WinTimestamp> {
         let win_timestamp = WinTimestamp(reader.read_u64::<LittleEndian>()?);

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::fmt::{Debug, Display};
 use std::io::{Cursor, Read};
 
-#[derive(Clone)]
+#[derive(Serialize, Clone)]
 /// https://docs.microsoft.com/en-us/windows/desktop/api/minwinbase/ns-minwinbase-filetime
 /// Contains a 64-bit value representing the number of 100-nanosecond intervals since January 1, 1601 (UTC).
 /// # Example

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Duration, NaiveDate, Utc};
 use std::fmt;
 use std::fmt::{Debug, Display};
 use std::io::{Cursor, Read};
+use serde::Serialize;
 
 #[derive(Serialize, Clone)]
 /// https://docs.microsoft.com/en-us/windows/desktop/api/minwinbase/ns-minwinbase-filetime

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -45,6 +45,10 @@ impl WinTimestamp {
             Utc,
         )
     }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
 }
 
 impl Display for WinTimestamp {


### PR DESCRIPTION
I applied some interface changes to allow r-winreg to use omerbenamram/winstructs instead of forensicmatt/r-winstructs,
because @forensicmatt suggests to use the implementation by @omerbenamram 