### PR TITLE
Removed unnecessary `env_logger` dependency. Added CI status to README.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,17 +1,16 @@
-name: Build an Test
+name: Build and Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,14 +18,14 @@ jobs:
         rust: [stable]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: ⚙️ Install Rust
-      run: |
-        rustup update ${{ matrix.rust }}
-        rustup default ${{ matrix.rust }}
-    - name: 🔨 Build
-      run: cargo build --verbose
-    - name: 🧪 Run Tests
-      run: cargo test --verbose
-    - name: 📎 Run Clippy
-      run: cargo clippy --release
+      - uses: actions/checkout@v3
+      - name: ⚙️ Install Rust
+        run: |
+          rustup update ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+      - name: 🔨 Build
+        run: cargo build --verbose
+      - name: 🧪 Run Tests
+        run: cargo test --verbose
+      - name: 📎 Run Clippy
+        run: cargo clippy --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2023-08-14
+
+Removed unnecessary `env_logger` dependency. Added CI status to README.
+
 ## [0.3.1] - 2023-08-08
 
 Removed default features for `chrono` in order to eliminate subdependency on `time@0.1.45`. Removing this subdependency is required by an advisory [here (CVE-2020-26235)](https://github.com/chronotope/chrono/issues/602).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,11 @@ repository = "https://github.com/omerbenamram/winstructs/tree/master"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
-version = "0.3.1"
-authors = ["Omer Ben-Amram <omerbenamram@gmail.com>", "Matthew Seyer <matthew.seyer@gmail.com>"]
+version = "0.3.2"
+authors = [
+    "Omer Ben-Amram <omerbenamram@gmail.com>",
+    "Matthew Seyer <matthew.seyer@gmail.com>",
+]
 edition = "2018"
 
 [dependencies]
@@ -16,8 +19,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bitflags = "1.2"
 byteorder = "1.3"
-env_logger = "0.7"
 num-traits = "0.2"
 num-derive = "0.3"
 thiserror = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "serde",
+    "std",
+] }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![crates.io](https://img.shields.io/crates/v/winstructs.svg)
+[![Build Status](https://github.com/omerbenamram/winstructs/actions/workflows/pipeline.yml/badge.svg)](https://github.com/voidbar/winstructs/actions)
+[![crates.io](https://img.shields.io/crates/v/winstructs.svg)](https://docs.rs/winstructs/latest/winstructs/)
 
 # winstructs
 This crate contains definitions and some parsing logic for structures that are common across windows formats.

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -39,8 +39,7 @@ impl WinTimestamp {
 
         // Add microseconds to timestamp via Duration
         DateTime::from_utc(
-            NaiveDate::from_ymd(1601, 1, 1).and_hms_nano(0, 0, 0, 0)
-                + Duration::microseconds((nanos_since_windows_epoch / 10) as i64),
+            NaiveDate::from_ymd_opt(1601, 1, 1).and_then(|x| x.and_hms_nano_opt(0, 0, 0, 0)).expect("to_datetime() should work") + Duration::microseconds((nanos_since_windows_epoch / 10) as i64),
             Utc,
         )
     }
@@ -87,7 +86,7 @@ impl DosDate {
 
         let year = (self.0 >> 9) + 1980;
 
-        chrono::NaiveDate::from_ymd(i32::from(year), u32::from(month), u32::from(day))
+        chrono::NaiveDate::from_ymd_opt(i32::from(year), u32::from(month), u32::from(day)).expect("to_date() should work")
     }
 
     pub fn to_date_formatted(&self, format: &str) -> String {
@@ -124,7 +123,7 @@ impl DosTime {
         let min = (self.0 >> 5) & 0x3F;
         let hour = (self.0 >> 11) & 0x1F;
 
-        chrono::NaiveTime::from_hms(u32::from(hour), u32::from(min), u32::from(sec))
+        chrono::NaiveTime::from_hms_opt(u32::from(hour), u32::from(min), u32::from(sec)).expect("to_time() should work")
     }
 }
 


### PR DESCRIPTION
Removing env_logger which uses the `atty` crate which is unmaintained and [has security vulnerabilities](https://github.com/advisories/GHSA-g98v-hv3f-hcfr). In any case env_logger is not being used by the code so there is no reason not to remove it 🙂